### PR TITLE
Don’t assume readonly queries must return results

### DIFF
--- a/src/objects/database/create-statement.cc
+++ b/src/objects/database/create-statement.cc
@@ -45,9 +45,6 @@ NAN_METHOD(Database::CreateStatement) {
 		stmt->column_count = 0;
 	} else {
 		stmt->column_count = sqlite3_column_count(stmt->st_handle);
-		if (stmt->column_count < 1) {
-			return Nan::ThrowTypeError("This read-only SQL statement returns no result columns.");
-		}
 	}
 	Nan::ForceSet(statement, NEW_INTERNAL_STRING_FAST("source"), source, FROZEN);
 	Nan::ForceSet(statement, NEW_INTERNAL_STRING_FAST("database"),  info.This(), FROZEN);


### PR DESCRIPTION
When we started running N1 on top of `better-sqlite3`, it threw exceptions when executing queries that do not modify the database but also do not return values. I think there are some legitimate uses for these queries.

Removing the check didn't break anything, so maybe we could just toss it?

Example query:
```
CREATE TABLE IF NOT EXISTS `File` (id TEXT PRIMARY KEY,data BLOB,client_id TEXT,account_id TEXT,filename TEXT)
```

I'm not 100% sure, but I believe `BEGIN TRANSACTION` and `COMMIT` are also queries that are classified as read-only but return nothing.