### PR TITLE
Fix macros.h to support ia32 on Windows (#9)

### DIFF
--- a/src/util/macros.h
+++ b/src/util/macros.h
@@ -30,7 +30,7 @@ inline char* C_STRING(v8::Local<v8::String> string) {
 
 // Given a double, returns whether the number is a valid 32-bit signed integer.
 inline bool IS_32BIT_INT(double num) {
-	return floor(num) == num && num < 2147483648L && num >= -2147483647L - 1;
+	return floor(num) == num && num < 2147483648.0 && num >= -2147483648.0;
 }
 
 // Creates a stack-allocated std:string of the concatenation of 2 well-formed

--- a/src/util/macros.h
+++ b/src/util/macros.h
@@ -30,7 +30,7 @@ inline char* C_STRING(v8::Local<v8::String> string) {
 
 // Given a double, returns whether the number is a valid 32-bit signed integer.
 inline bool IS_32BIT_INT(double num) {
-	return floor(num) == num && num < 2147483648 && num >= -2147483648;
+	return floor(num) == num && num < 2147483648L && num >= -2147483647L - 1;
 }
 
 // Creates a stack-allocated std:string of the concatenation of 2 well-formed


### PR DESCRIPTION
Just applied the solution from here and checked that the project compiled without warnings and works: http://stackoverflow.com/questions/29355956/how-can-i-fix-error-code-c4146-unary-minus-operator-applied-to-unsigned-type-re

Resolves #9