### PR TITLE
Fix error in jest where database methods sometimes don't exist

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -52,7 +52,4 @@ function Database(filenameGiven, options) {
 util.wrap(CPPDatabase, 'pragma', require('./pragma'));
 util.wrap(CPPDatabase, 'register', require('./register'));
 CPPDatabase.prototype.constructor = Database;
-Database.prototype = Object.create(Object.prototype, toDescriptor(CPPDatabase.prototype));
-Object.keys(CPPDatabase.prototype).forEach(function (method) {delete CPPDatabase.prototype[method];});
-Object.setPrototypeOf(CPPDatabase.prototype, Database.prototype);
 module.exports = Database;

--- a/lib/database.js
+++ b/lib/database.js
@@ -52,4 +52,6 @@ function Database(filenameGiven, options) {
 util.wrap(CPPDatabase, 'pragma', require('./pragma'));
 util.wrap(CPPDatabase, 'register', require('./register'));
 CPPDatabase.prototype.constructor = Database;
+Database.prototype = Object.create(Object.prototype, toDescriptor(CPPDatabase.prototype));
+Object.setPrototypeOf(CPPDatabase.prototype, Database.prototype);
 module.exports = Database;


### PR DESCRIPTION
I'm working on getting better-sqlite3 to play nicely with jest. I solve my first problem in the integer library, PR here: https://github.com/JoshuaWise/integer/pull/3

It seems to run fine, but for some reason, some of the tests get a Database object that looks correct but doesn't have methods on it (prepare, exec, etc just don't exist). Removing the 3 lines in PR fixes the problem and everything runs fine. What is this code doing?

The way I'm using it is before every single test that needs a database (there are a lot of them) it creates a fresh in-memory db:

```js
global.emptyDatabase = function() {
  return () => {
    const memoryDB = new Database('/foo' + Math.random(), { memory: true });

    // This log is for debugging the issue
    console.log(memoryDB, memoryDB.exec);

    sqlite.execQuery(
      memoryDB,
      nativeFs.readFileSync(__dirname + '/../server/sql/init.sql', 'utf8')
    );

    db.setDatabase(memoryDB);
  };
};
```

Most of my tests run fine and the log statement has the expected results. But for some tests the output is:

```
Database {
        inTransaction: false,
        open: true,
        memory: true,
        readonly: false,
        name: '/foo0.16196358281721057' } undefined
```

Note that `db.exec` is undefined. Is it safe to simplify this code so that this works?

Sidenote: apparently even though I'm creating a new fresh in-memory db each time, I have to give it a unique name. If I pass the same filename through, it retrieves the previous in-memory db. Why is that? It seems like if I create an in-memory db is shouldn't ever be retrievable with future `new Database` calls.