### PR TITLE
Edit possible typo, "arguement" --> "argument"

### DIFF
--- a/src/util/macros.lzz
+++ b/src/util/macros.lzz
@@ -36,7 +36,7 @@ void ThrowRangeError(const char* message) { EasyIsolate; isolate->ThrowException
 
 #define _REQUIRE_ARGUMENT(at, var, Type, message, ...)                         \
 	if (info.Length() <= (at()) || !info[at()]->Is##Type())                    \
-		return ThrowTypeError("Expected "#at" arguement to be "#message);      \
+		return ThrowTypeError("Expected "#at" argument to be "#message);      \
 	var = v8::Local<v8::Type>::Cast(info[at()])__VA_ARGS__
 
 #define REQUIRE_ARGUMENT_INT32(at, var)                                        \


### PR DESCRIPTION
Found a small typo in the `TypeError` messaging.