### PR TITLE
Allow creating private, non-shared :memory: DBs

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -17,9 +17,6 @@ function Database(filenameGiven, options) {
 	if (/^file:/i.test(filename)) {
 		throw new TypeError('URI filenames are reserved for internal use only');
 	}
-	if (/^(:memory:)?$/i.test(filename)) {
-		throw new TypeError('To create an in-memory database, specify a normal filename and use the "memory" option');
-	}
 	
 	if (typeof options !== 'object' || options === null) {
 		options = {};

--- a/test/10.database.open.js
+++ b/test/10.database.open.js
@@ -21,8 +21,14 @@ describe('new Database()', function () {
 		expect(() => new Database(`file: ${util.next()}`)).to.throw(TypeError);
 		expect(() => new Database(`file: ${util.next()}?mode=memory&cache=shared`)).to.throw(TypeError);
 	});
-	it('should not allow ":memory:" databases', function () {
-		expect(() => new Database(':memory:')).to.throw(TypeError);
+	it('should allow private in-memory databases with ":memory:"', function () {
+		// See additional tests in `test/16.database.private-memory.js`.
+		const db = new Database(':memory:');
+		expect(db.name).to.equal(':memory:');
+		expect(db.memory).to.be.false;  // not a shared-memory database
+		expect(db.readonly).to.be.false;
+		expect(db.open).to.be.true;
+		expect(db.inTransaction).to.be.false;
 	});
 	it('should allow disk-based databases to be created', function () {
 		expect(() => fs.accessSync(util.next())).to.throw(Error);

--- a/test/16.database.private-memory.js
+++ b/test/16.database.private-memory.js
@@ -1,0 +1,43 @@
+'use strict';
+const { expect } = require('chai');
+const fs = require('fs');
+const Database = require('../.');
+
+describe('Database(":memory:")', function () {
+	function tableCount(db) {
+		return db.prepare('SELECT COUNT(1) AS n FROM sqlite_master').get().n;
+	}
+	it('should not actually touch a file called :memory:', function () {
+		expect(fs.existsSync(':memory:')).to.be.false;
+		new Database(':memory:');
+		expect(fs.existsSync(':memory:')).to.be.false;
+	});
+	it('should be isolated', function () {
+		const db0 = new Database(':memory:');
+		const db1 = new Database(':memory:');
+		db0.prepare('CREATE TABLE tab (col)').run();
+		expect(tableCount(db0)).to.equal(1);
+		expect(tableCount(db1)).to.equal(0);
+		db0.close();
+		db1.close();
+		const db2 = new Database(':memory:');
+		expect(tableCount(db2)).to.equal(0);
+	});
+	it('should be shared among databases with "memory" set to true', function () {
+		const db0 = new Database(':memory:', { memory: true });
+		const db1 = new Database(':memory:', { memory: true });
+		const db2 = new Database(':memory:');
+		db0.prepare('CREATE TABLE tab (col)').run();
+		expect(tableCount(db0)).to.equal(1);
+		expect(tableCount(db1)).to.equal(1);
+		expect(tableCount(db2)).to.equal(0);
+	});
+	it('should obey the restrictions of readonly mode', function () {
+		const db = new Database(':memory:', {readonly: true});
+		const stmt = db.prepare('CREATE TABLE tab (col)');
+		expect(() => stmt.run()).to.throw(Database.SqliteError).with.property('code', 'SQLITE_READONLY');
+	});
+	it('should ignore "fileMustExist"', function () {
+		new Database(':memory:', { readonly: true, fileMustExist: true });
+	});
+});


### PR DESCRIPTION
Summary:
Currently, `better-sqlite3` allows creating in-memory databases by
setting `memory: true` in `options`. However, these databases are shared
across all clients who provide the same (fake) filename. This may be
useful for some applications, but it means that clients who want to
actually encapsulate their databases have no way to do so.

This patch adds support for the standard SQLite `:memory:` file path,
which creates a _private_ in-memory database. The `{memory: true}`
option is retained to support _shared_ in-memory databases

Resolves #87.

After this commit is merged, the wiki should be changed as follows:

```diff
diff --git a/API.md b/API.md
index 2610e0c..27bf4e0 100644
--- a/API.md
+++ b/API.md
@@ -15,12 +15,18 @@

 Creates a new database connection. If the database file does not exist, it is created. This happens synchronously, which means you can start executing queries right away.

-- If `options.memory` is `true`, an in-memory database will be created, rather than a disk-bound one. Default is `false`.
+- If `path` is `:memory:`, a _private_ in-memory database will be created. No other client will be able to open a connection to this database. No file will be created on disk.
+
+- If `options.memory` is `true`, a _shared_ in-memory database will be created. No file will be created on disk. Other clients can open a connection to this database by using the same filename and setting `options.memory` to `true`. Default is `false`.

 - If `options.readonly` is `true`, the database connection will be opened in readonly mode. Default is `false`.

 - If `options.fileMustExist` is `true` and the database does not exist, an `Error` will be thrown instead of creating a new file. This option does not affect in-memory or readonly database connections. Default is `false`.

+See [the SQLite documentation on in-memory databases][sqlite-inmemorydb] for more details on the difference between private caches (`:memory:`) and shared caches (setting `options.memory` to `true`).
+
+[sqlite-inmemorydb]: https://sqlite.org/inmemorydb.html
+
 ### .prepare(*string*) -> *Statement*

 Creates a new prepared [`Statement`](#class-statement) from the given SQL string.
```

Test Plan:
All existing unit tests pass, except for the one that explicitly checks
that this is not possible: it has been updated. Newly added unit tests
check that these databases are indeed isolated.

wchargin-branch: private-inmemory-db