### PR TITLE
Verify non-trivial batches of inserts are all persisted

### DIFF
--- a/test/23.statement.iterate.js
+++ b/test/23.statement.iterate.js
@@ -247,8 +247,8 @@ describe('Statement#iterate()', function () {
 		).to.throw(TypeError);
 	});
 
-	it.only("should read and write non-trivial numbers of rows", function () {
-		const insertRuntime = 10000
+	it("should read and write non-trivial numbers of rows", function () {
+		const insertRuntime = 1000
 		this.timeout(insertRuntime * 2.5);
 		const runUntil = Date.now() + insertRuntime
 	  let i = 0;

--- a/test/23.statement.iterate.js
+++ b/test/23.statement.iterate.js
@@ -247,11 +247,11 @@ describe('Statement#iterate()', function () {
 		).to.throw(TypeError);
 	});
 	it("should read and write non-trivial numbers of rows", function () {
-		const insertRuntime = 1000
+		const insertRuntime = 1000;
 		this.timeout(insertRuntime * 2.5);
-		const runUntil = Date.now() + insertRuntime
+		const runUntil = Date.now() + insertRuntime;
 		let i = 0;
-		const r = .141592654
+		const r = .141592654;
 		this.db.prepare('CREATE TABLE t (id INTEGER, b TEXT, c REAL)').run();
 		const stmt = this.db.prepare("INSERT INTO t VALUES (?, ?, ?)");
 		while (Date.now() < runUntil) {
@@ -268,13 +268,13 @@ describe('Statement#iterate()', function () {
 		expect(i).to.be.gte(1000); // < expect ~50K and 200K on reasonable machines
 		const stmt1 = this.db.prepare("SELECT * FROM t ORDER BY id DESC");
 		for (const data of stmt1.iterate()) {
-			i--
+			i--;
 			expect(data).to.deep.equal({
 				id: i,
 				b: String(i),
 				c: i + r
-			})
+			});
 		}
-		expect(i).to.equal(0)
+		expect(i).to.equal(0);
 	});
 });

--- a/test/23.statement.iterate.js
+++ b/test/23.statement.iterate.js
@@ -246,19 +246,18 @@ describe('Statement#iterate()', function () {
 			this.db.prepare(SQL1).iterate('foo', 1, new (function(){})(), Buffer.alloc(4).fill(0xdd), null)
 		).to.throw(TypeError);
 	});
-
 	it("should read and write non-trivial numbers of rows", function () {
 		const insertRuntime = 1000
 		this.timeout(insertRuntime * 2.5);
 		const runUntil = Date.now() + insertRuntime
-	  let i = 0;
+		let i = 0;
 		const r = .141592654
-	  this.db.prepare('CREATE TABLE t (id INTEGER, b TEXT, c REAL)').run();
+		this.db.prepare('CREATE TABLE t (id INTEGER, b TEXT, c REAL)').run();
 		const stmt = this.db.prepare("INSERT INTO t VALUES (?, ?, ?)");
-		while(Date.now() < runUntil) {
+		while (Date.now() < runUntil) {
 			// Batched transactions of 100 inserts:
 			this.db.transaction(() => {
-				for(const start = i; i < start + 100 ; i++) {
+				for (const start = i; i < start + 100; i++) {
 					expect(stmt.run([i, String(i), i + r])).to.deep.equal({
 						changes: 1,
 						lastInsertRowid: i + 1
@@ -267,15 +266,15 @@ describe('Statement#iterate()', function () {
 			})();
 		}
 		expect(i).to.be.gte(1000); // < expect ~50K and 200K on reasonable machines
-	  const stmt1 = this.db.prepare("SELECT * FROM t ORDER BY id DESC");
-	  for (const data of stmt1.iterate()) {
+		const stmt1 = this.db.prepare("SELECT * FROM t ORDER BY id DESC");
+		for (const data of stmt1.iterate()) {
 			i--
-	    expect(data).to.deep.equal({
-	      id: i,
-	      b: String(i),
-	      c: i + r
-	    })
-	  }
-	  expect(i).to.equal(0)
+			expect(data).to.deep.equal({
+				id: i,
+				b: String(i),
+				c: i + r
+			})
+		}
+		expect(i).to.equal(0)
 	});
 });

--- a/test/23.statement.iterate.js
+++ b/test/23.statement.iterate.js
@@ -247,9 +247,10 @@ describe('Statement#iterate()', function () {
 		).to.throw(TypeError);
 	});
 
-	it("should read and write non-trivial numbers of rows", function () {
-		this.timeout(5000);
-		const runUntil = Date.now() + 1000
+	it.only("should read and write non-trivial numbers of rows", function () {
+		const insertRuntime = 10000
+		this.timeout(insertRuntime * 2.5);
+		const runUntil = Date.now() + insertRuntime
 	  let i = 0;
 		const r = .141592654
 	  this.db.prepare('CREATE TABLE t (id INTEGER, b TEXT, c REAL)').run();


### PR DESCRIPTION
Another, unnamed sqlite node module fails a test just like this a large fraction of the time even with just 1000 rows. Rows just go missing.

`better-sqlite3` passes solidly with 1m rows.

Note that this test has a `runtime` const which I picked a value of a second, but that does mean this test suite takes 9 seconds rather than 7 seconds. Feel free to adjust as you see fit.

(Also, please consider adding `prettier`, it'd make matching your existing code a lot easier!)