### PR TITLE
Add support for building in VS2019

### DIFF
--- a/deps/common.gypi
+++ b/deps/common.gypi
@@ -7,7 +7,6 @@
   'variables': { 'sqlite3%': '' },
   'target_defaults': {
     'default_configuration': 'Release',
-    'msbuild_toolset': '',
     'msvs_settings': {
       'VCCLCompilerTool': {
         'ExceptionHandling': 1,


### PR DESCRIPTION
This adds support for building from source with VS2017 and VS2019. The latest versions of `node-gyp` have support for these now.

Solves #251 