### PR TITLE
Prebuild

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,71 @@
 language: node_js
 sudo: false
-node_js: 10
 matrix:
   include:
-  - os: linux
-    env: MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
-    addons:
-      apt:
-        sources:
-        - ubuntu-toolchain-r-test
-        packages:
-        - gcc-4.9
-        - g++-4.9
-  - os: osx
-    osx_image: xcode11
-    compiler: clang
-    env: MATRIX_EVAL="CC=gcc && CXX=g++"
+    # linux builds
+    - name: "Linux - Node 8"
+      os: linux
+      node_js: "8"
+      env: 
+        - CXX="g++-4.9"
+        - CC=gcc-4.9
+      addons:
+        apt:
+          sources:
+          - ubuntu-toolchain-r-test
+          packages:
+          - gcc-4.9
+          - g++-4.9
+    - name: "Linux - Node 10"
+      os: linux
+      node_js: "10"
+      env: 
+        - CXX="g++-4.9"
+        - CC=gcc-4.9
+      addons:
+        apt:
+          sources:
+          - ubuntu-toolchain-r-test
+          packages:
+          - gcc-4.9
+          - g++-4.9
+    - name: "Linux - Node 12"
+      os: linux
+      node_js: "12"
+      env: 
+        - CXX="g++-4.9"
+        - CC=gcc-4.9
+      addons:
+        apt:
+          sources:
+          - ubuntu-toolchain-r-test
+          packages:
+          - gcc-4.9
+          - g++-4.9
+    - name: "OS X - Node 8"
+      os: osx
+      node_js: "8"
+      osx_image: xcode11
+      compiler: clang
+      env: 
+        - CXX=g++
+        - CC=gcc
+    - name: "OS X - Node 10"
+      os: osx
+      node_js: "10"
+      osx_image: xcode11
+      compiler: clang
+      env: 
+        - CXX=g++
+        - CC=gcc
+    - name: "OS X - Node 12"
+      os: osx
+      node_js: "12"
+      osx_image: xcode11
+      compiler: clang
+      env: 
+        - CXX=g++
+        - CC=gcc
 before_script:
 - npm run install-debug
 before_deploy:
@@ -25,10 +75,11 @@ before_deploy:
 deploy:
   provider: releases
   api_key:
-    secure: i1mMbOqJ2wfhoDQQJhxZj2KpOucUw/lO2kzp+nmA1eXv+aqtIkuGeZj+zk9CNTOEvWMBsrnWHM1yXJSrzxVRr/vcYW1srQWg/KB8V0I0MiFcLMi3EfSB5O4vyHyd73Ozjf3waGg22UFkPo5BsbbI9EI3akL5smxDheuLc64FOfszxsPrmXCZH/T7Oy33zqmr8b2N5lO5WhacHW3nEUGXShrUZF52MWjtw9hy4y9FzShIxatD0DfUFwOKKRL5G8Y0qgY3iVeDtNF0UBBWX15wRTBYvdFeJEAWcr7moiZnbGllg4LLyYzkkTAdbBoCk5jM1LNaR5++rUsRpfiMN18eNk8LIZssbhL4IiWTUIjc1U/ktnXFqBFlGpfAUxH6qbsAkQGwTvJvZo0m9FSM9vv6iqfNMY6DMpUhwrqBFQjTzIdPUz9DUP097YbByc8mXMbw8MqFHDzl1+7nkrlhr0sW3RFgXooa4yYPIPRsuvizAxJ7nHrbDisKXPTQNnWez9mYBqGJpjtYoTTQcnMehXfmAT1Iv/UvSJnHAHt3ncIcCuuA61M2MxW0CkDC8QpZ2OH3dT+l/LGdpAbMU04XCWi1sXWY0p7ioeQjejjKGI7/lbDrWbCVT6nqy/XqYZcGy9ES4dMVxht0bWTqfcBvmVvSdKnsYSzm3lfJrRCl3VqS0vw=
+    secure: DU537mo7UzDlB0tgd/CX6VDwi2tE1KuBfEEO5+YBD9EfPNPbgs8NPOxdpBOhJIuuclHqouHF9JQ+L4plaQvRqNOoS2BT7fuftKfgzDamBchHgW9xi3TkF03YG5EFDgnb8NeAW2Ke5sABAS8dep3JL/AAeiQQ/SWDZAlhosW3OmGCDT8pCeV5nLQ/wwf0WMkkeEXCvJ6iA16SLf7FknNPdWU213noB2bHgLaku7Ozxt6256ntuBARABDZj6zgLPTCl7AOu+CjhIRCg/ogdyY6C8qWkBAQt97Rdz7wSbE7ub/AdOcdR2SynG6NeuPIxojT9Iy3jpYuULF9dJo+NwsPvBtTES7FS4LtNDglunQG98VT1A1rc+LbYBLxWELe9usQO3i1dDvf/KOUMOt5vLBpiffZq34rMnNsAlZepmyYLsp9Ui212jHZhcGPk8vFqX0BCyJUN6wzyp6KRGCRYInbKMJJoJyrYUk2AWoaxojdQf/Ha1Kb2xJfCep+Ny6nI9oyGFh8P937/6wjtLa8Drgrt15o5kkaUR5HluEBINgrYj/3VNgZkZWX1YG2eW3HiOylU/aBtrpKM7n4FYJfAiqAJbZ7FkK+Lk65sdLit0wrvt+8EO+GG8RUreXSf21iJmvjX/A106cGCpiC4AKG1drJjjxbCi/iTRid/+Aldq98k5A=
   file: prebuilds/*
   file_glob: true
   skip_cleanup: true
   on:
     repo: danielbarela/better-sqlite3
     tags: true
+    node_js: "10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,34 @@
 language: node_js
 sudo: false
-node_js:
-- "8"
-- "10"
-- "12"
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - gcc-4.9
-    - g++-4.9
-before_install:
-- export CC="gcc-4.9" CXX="g++-4.9"
+node_js: 10
+matrix:
+  include:
+  - os: linux
+    env: MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - gcc-4.9
+        - g++-4.9
+  - os: osx
+    osx_image: xcode11
+    compiler: clang
+    env: MATRIX_EVAL="CC=gcc && CXX=g++"
 before_script:
 - npm run install-debug
+before_deploy:
+- npm install
+- npm run prebuild
+- npm run prebuild-electron
+deploy:
+  provider: releases
+  api_key:
+    secure: i1mMbOqJ2wfhoDQQJhxZj2KpOucUw/lO2kzp+nmA1eXv+aqtIkuGeZj+zk9CNTOEvWMBsrnWHM1yXJSrzxVRr/vcYW1srQWg/KB8V0I0MiFcLMi3EfSB5O4vyHyd73Ozjf3waGg22UFkPo5BsbbI9EI3akL5smxDheuLc64FOfszxsPrmXCZH/T7Oy33zqmr8b2N5lO5WhacHW3nEUGXShrUZF52MWjtw9hy4y9FzShIxatD0DfUFwOKKRL5G8Y0qgY3iVeDtNF0UBBWX15wRTBYvdFeJEAWcr7moiZnbGllg4LLyYzkkTAdbBoCk5jM1LNaR5++rUsRpfiMN18eNk8LIZssbhL4IiWTUIjc1U/ktnXFqBFlGpfAUxH6qbsAkQGwTvJvZo0m9FSM9vv6iqfNMY6DMpUhwrqBFQjTzIdPUz9DUP097YbByc8mXMbw8MqFHDzl1+7nkrlhr0sW3RFgXooa4yYPIPRsuvizAxJ7nHrbDisKXPTQNnWez9mYBqGJpjtYoTTQcnMehXfmAT1Iv/UvSJnHAHt3ncIcCuuA61M2MxW0CkDC8QpZ2OH3dT+l/LGdpAbMU04XCWi1sXWY0p7ioeQjejjKGI7/lbDrWbCVT6nqy/XqYZcGy9ES4dMVxht0bWTqfcBvmVvSdKnsYSzm3lfJrRCl3VqS0vw=
+  file: prebuilds/*
+  file_glob: true
+  skip_cleanup: true
+  on:
+    repo: danielbarela/better-sqlite3
+    tags: true

--- a/binding.gyp
+++ b/binding.gyp
@@ -24,14 +24,5 @@
       'dependencies': ['deps/sqlite3.gyp:sqlite3'],
       'conditions': [['sqlite3 == ""', { 'sources': ['deps/test_extension.c'] }]],
     },
-    {
-      'target_name': 'place_resulting_binaries',
-      'type': 'none',
-      'dependencies': ['better_sqlite3', 'test_extension'],
-      'copies': [{
-        'files': ['<(PRODUCT_DIR)/better_sqlite3.node', '<(PRODUCT_DIR)/test_extension.node'],
-        'destination': 'build',
-      }],
-    },
   ],
 }

--- a/lib/database.js
+++ b/lib/database.js
@@ -2,7 +2,18 @@
 const fs = require('fs');
 const path = require('path');
 const util = require('./util');
-const CPPDatabase = require('bindings')('better_sqlite3.node').Database;
+
+const releaseFilepath = require('path').join(__dirname, '..', 'build', 'Release', 'better_sqlite3.node');
+const debugFilepath = require('path').join(__dirname, '..', 'build', 'Debug', 'better_sqlite3.node');
+let filepath;
+try {
+	fs.accessSync(releaseFilepath, fs.constants.F_OK);
+	filepath = releaseFilepath;
+} catch (e) {
+	filepath = debugFilepath;
+}
+
+const CPPDatabase = require(filepath).Database;
 
 function Database(filenameGiven, options) {
 	if (filenameGiven == null) filenameGiven = '';

--- a/lib/database.js
+++ b/lib/database.js
@@ -3,17 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const util = require('./util');
 
-const releaseFilepath = require('path').join(__dirname, '..', 'build', 'Release', 'better_sqlite3.node');
-const debugFilepath = require('path').join(__dirname, '..', 'build', 'Debug', 'better_sqlite3.node');
-let filepath;
-try {
-	fs.accessSync(releaseFilepath, fs.constants.F_OK);
-	filepath = releaseFilepath;
-} catch (e) {
-	filepath = debugFilepath;
-}
-
-const CPPDatabase = require(filepath).Database;
+const CPPDatabase = require('bindings')('better_sqlite3.node').Database;
 
 function Database(filenameGiven, options) {
 	if (filenameGiven == null) filenameGiven = '';

--- a/lib/database.js
+++ b/lib/database.js
@@ -2,7 +2,7 @@
 const fs = require('fs');
 const path = require('path');
 const util = require('./util');
-const CPPDatabase = require('../build/better_sqlite3.node').Database;
+const CPPDatabase = require('bindings')('better_sqlite3.node').Database;
 
 function Database(filenameGiven, options) {
 	if (filenameGiven == null) filenameGiven = '';

--- a/package.json
+++ b/package.json
@@ -10,8 +10,11 @@
     "url": "git://github.com/JoshuaWise/better-sqlite3.git"
   },
   "dependencies": {
+    "bindings": "1.5.0",
     "integer": "^2.1.0",
-    "tar": "^4.4.10"
+    "tar": "^4.4.10",
+    "prebuild-install": "^5.3.2",
+    "prebuild": "^9.1.1"
   },
   "devDependencies": {
     "chai": "^4.2.0",
@@ -22,6 +25,7 @@
     "sqlite": "^3.0.3"
   },
   "scripts": {
+    "install": "prebuild-install || node-gyp rebuild",
     "download": "sh ./deps/download.sh",
     "lzz": "lzz -hx hpp -sx cpp -k BETTER_SQLITE3 -d -hl -sl -e ./src/better_sqlite3.lzz",
     "prepublishOnly": "npm run lzz",
@@ -29,7 +33,9 @@
     "rebuild": "npm run lzz && node-gyp rebuild",
     "rebuild-debug": "npm run lzz && node-gyp rebuild --debug",
     "test": "mocha --exit --slow=75 --timeout=5000",
-    "benchmark": "node benchmark"
+    "benchmark": "node benchmark",
+    "prebuild-electron": "prebuild -r electron -t 2.0.0 -t 3.0.0 -t 4.0.0 -t 5.0.0 -t 6.0.0 -t 7.0.0",
+    "prebuild": "prebuild -r node -t 8.0.0 -t 10.0.0 -t 12.0.0"
   },
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "rebuild-debug": "npm run lzz && node-gyp rebuild --debug",
     "test": "mocha --exit --slow=75 --timeout=5000",
     "benchmark": "node benchmark",
-    "prebuild-electron": "prebuild -r electron -t 2.0.0 -t 3.0.0 -t 4.0.0 -t 5.0.0 -t 6.0.0 -t 7.0.0",
-    "prebuild": "prebuild -r node -t 8.0.0 -t 10.0.0 -t 12.0.0"
+    "prebuild-electron": "prebuild -r electron -t 2.0.0 -t 3.0.0 -t 4.0.0 -t 5.0.0 -t 6.0.0 -t 7.0.0 --include-regex 'better_sqlite3.node$'",
+    "prebuild": "prebuild -r node -t 8.0.0 -t 10.0.0 -t 12.0.0 --include-regex 'better_sqlite3.node$'"
   },
   "license": "MIT",
   "keywords": [

--- a/src/better_sqlite3.cpp
+++ b/src/better_sqlite3.cpp
@@ -457,7 +457,7 @@ void Database::Init (v8::Isolate * isolate, v8::Local <v8 :: Object> exports, v8
 
                 v8 :: Local < v8 :: Context > ctx = isolate -> GetCurrentContext ( ) ;
                 exports->Set(ctx, StringFromUtf8(isolate, "Database", -1), t->GetFunction(ctx).ToLocalChecked()).FromJust();
-                SqliteError.Reset(isolate, v8::Local<v8::Function>::Cast(Require(module, "../lib/sqlite-error")));
+                SqliteError.Reset(isolate, v8::Local<v8::Function>::Cast(Require(module, "../../lib/sqlite-error")));
                 node::AtExit(Database::AtExit);
 }
 #line 132 "./src/objects/database.lzz"

--- a/test/34.database.load-extension.js
+++ b/test/34.database.load-extension.js
@@ -2,7 +2,16 @@
 const Database = require('../.');
 
 util.describeUnix('Database#loadExtension()', function () {
-	const filepath = require('path').join(__dirname, '../build/test_extension.node');
+	const releaseFilepath = require('path').join(__dirname, '..', 'build', 'Release', 'test_extension.node');
+	const debugFilepath = require('path').join(__dirname, '..', 'build', 'Debug', 'test_extension.node');
+	let filepath;
+	try {
+		const fs = require('fs');
+		fs.accessSync(releaseFilepath, fs.constants.F_OK);
+		filepath = releaseFilepath;
+	} catch (e) {
+		filepath = debugFilepath;
+	}
 	beforeEach(function () {
 		this.db = new Database(util.next());
 	});

--- a/test/42.integrity.js
+++ b/test/42.integrity.js
@@ -166,7 +166,16 @@ describe('integrity checks', function () {
 	});
 
 	util.describeUnix('Database#loadExtension()', function () {
-		const filepath = require('path').join(__dirname, '../build/test_extension.node');
+		const releaseFilepath = require('path').join(__dirname, '..', 'build', 'Release', 'test_extension.node');
+		const debugFilepath = require('path').join(__dirname, '..', 'build', 'Debug', 'test_extension.node');
+		let filepath;
+		try {
+			const fs = require('fs');
+			fs.accessSync(releaseFilepath, fs.constants.F_OK);
+			filepath = releaseFilepath;
+		} catch (e) {
+			filepath = debugFilepath;
+		}
 		specify('while iterating (blocked)', function () {
 			whileIterating(this, blocked(() => this.db.loadExtension(filepath)));
 			normally(allowed(() => this.db.loadExtension(filepath)));


### PR DESCRIPTION
* This adds prebuild support.  When the library is released from GitHub a travis build will run which builds the library for Node 8, 10 and 12, and Electron 2 - 7
* Modifies the binding.gyp file to remove the copy command for the .node file.  This is unnecessary and leaves the file in two spots.  The code now loads the .node file from either the Release or Debug directory in the build folder.

- Important: when this is pulled, you will need to update the deploy section of the .travis.yml file to have your github token encrypted and modify the repository so that Travis will automatically push the artifacts when you create a release in GitHub