### PR TITLE
loadExtension: allow specifying extension entry point

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -24,5 +24,10 @@
       'dependencies': ['deps/sqlite3.gyp:sqlite3'],
       'conditions': [['sqlite3 == ""', { 'sources': ['deps/test_extension.c'] }]],
     },
+    {
+      'target_name': 'test_extension_custom_entry_point',
+      'dependencies': ['deps/sqlite3.gyp:sqlite3'],
+      'conditions': [['sqlite3 == ""', { 'sources': ['deps/test_extension_custom_entry_point.c'] }]],
+    },
   ],
 }

--- a/deps/test_extension_custom_entry_point.c
+++ b/deps/test_extension_custom_entry_point.c
@@ -1,0 +1,26 @@
+#include <sqlite3ext.h>
+SQLITE_EXTENSION_INIT1
+
+/*
+	This SQLite3 extension is used only for testing purposes (npm test).
+
+	This extension differs from the regular 'test_extension' as it defines
+	a non-standard entry point.
+
+	see: https://github.com/JoshuaWise/better-sqlite3/issues/363
+ */
+
+static void TestExtensionFunction(sqlite3_context* pCtx, int nVal, sqlite3_value** _) {
+	sqlite3_result_double(pCtx, (double)nVal);
+}
+
+#ifdef _WIN32
+__declspec(dllexport)
+#endif
+
+int custom_extension_init(sqlite3* db, char** pzErrMsg, const sqlite3_api_routines* pApi) {
+	SQLITE_EXTENSION_INIT2(pApi)
+	if (pzErrMsg != 0) *pzErrMsg = 0;
+	sqlite3_create_function(db, "testExtensionFunction", -1, SQLITE_UTF8, 0, TestExtensionFunction, 0, 0);
+	return SQLITE_OK;
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -244,7 +244,7 @@ db.prepare(`
 `).all();
 ```
 
-### .loadExtension(*path*) -> *this*
+### .loadExtension(*path*, [*entry_point*]) -> *this*
 
 Loads a compiled [SQLite3 extension](https://sqlite.org/loadext.html) and applies it to the current database connection.
 

--- a/src/better_sqlite3.cpp
+++ b/src/better_sqlite3.cpp
@@ -662,14 +662,23 @@ void Database::JS_loadExtension (v8::FunctionCallbackInfo <v8 :: Value> const & 
                 if ( db -> iterators ) return ThrowTypeError ( "This database connection is busy executing a query" ) ;
                 v8::String::Utf8Value filename(EXTRACT_STRING( info . GetIsolate ( ) , filenameString));
                 char* error;
-                int status = sqlite3_load_extension(db->db_handle, *filename, NULL, &error);
+                int status;
+
+
+                if (info.Length() > 1) {
+                        if ( info . Length ( ) <= ( 1 ) || ! info [ 1 ] -> IsString ( ) ) return ThrowTypeError ( "Expected " "second" " argument to be " "a string" ) ; v8 :: Local < v8 :: String > entryPointString = v8 :: Local < v8 :: String > :: Cast ( info [ 1 ] ) ;
+                        v8::String::Utf8Value entry_point(EXTRACT_STRING( info . GetIsolate ( ) , entryPointString));
+                        status = sqlite3_load_extension(db->db_handle, *filename, *entry_point, &error);
+                } else {
+                        status = sqlite3_load_extension(db->db_handle, *filename, NULL, &error);
+                }
                 if (status == SQLITE_OK) info.GetReturnValue().Set(info.This());
                 else ThrowSqliteError(error, status);
                 sqlite3_free(error);
 }
-#line 321 "./src/objects/database.lzz"
+#line 330 "./src/objects/database.lzz"
 void Database::JS_close (v8::FunctionCallbackInfo <v8 :: Value> const & info)
-#line 321 "./src/objects/database.lzz"
+#line 330 "./src/objects/database.lzz"
                               {
                 Database* db = node :: ObjectWrap :: Unwrap <Database>(info.This());
                 if (db->open) {
@@ -680,31 +689,31 @@ void Database::JS_close (v8::FunctionCallbackInfo <v8 :: Value> const & info)
                 }
                 info.GetReturnValue().Set(info.This());
 }
-#line 332 "./src/objects/database.lzz"
+#line 341 "./src/objects/database.lzz"
 void Database::JS_defaultSafeIntegers (v8::FunctionCallbackInfo <v8 :: Value> const & info)
-#line 332 "./src/objects/database.lzz"
+#line 341 "./src/objects/database.lzz"
                                             {
                 Database* db = node :: ObjectWrap :: Unwrap <Database>(info.This());
                 if (info.Length() == 0) db->safe_ints = true;
                 else { if ( info . Length ( ) <= ( 0 ) || ! info [ 0 ] -> IsBoolean ( ) ) return ThrowTypeError ( "Expected " "first" " argument to be " "a boolean" ) ; db -> safe_ints = v8 :: Local < v8 :: Boolean > :: Cast ( info [ 0 ] ) -> Value ( ) ; }
                 info.GetReturnValue().Set(info.This());
 }
-#line 339 "./src/objects/database.lzz"
+#line 348 "./src/objects/database.lzz"
 void Database::JS_open (v8::Local <v8 :: String> _, v8::PropertyCallbackInfo <v8 :: Value> const & info)
-#line 339 "./src/objects/database.lzz"
+#line 348 "./src/objects/database.lzz"
                              {
                 info.GetReturnValue().Set( node :: ObjectWrap :: Unwrap <Database>(info.This())->open);
 }
-#line 343 "./src/objects/database.lzz"
+#line 352 "./src/objects/database.lzz"
 void Database::JS_inTransaction (v8::Local <v8 :: String> _, v8::PropertyCallbackInfo <v8 :: Value> const & info)
-#line 343 "./src/objects/database.lzz"
+#line 352 "./src/objects/database.lzz"
                                       {
                 Database* db = node :: ObjectWrap :: Unwrap <Database>(info.This());
                 info.GetReturnValue().Set(db->open && !static_cast<bool>(sqlite3_get_autocommit(db->db_handle)));
 }
-#line 348 "./src/objects/database.lzz"
+#line 357 "./src/objects/database.lzz"
 void Database::CloseHandles ()
-#line 348 "./src/objects/database.lzz"
+#line 357 "./src/objects/database.lzz"
                             {
                 if (open) {
                         open = false;
@@ -716,20 +725,20 @@ void Database::CloseHandles ()
                         assert(status == SQLITE_OK); ((void)status);
                 }
 }
-#line 360 "./src/objects/database.lzz"
+#line 369 "./src/objects/database.lzz"
 void Database::AtExit (void * _)
-#line 360 "./src/objects/database.lzz"
+#line 369 "./src/objects/database.lzz"
                                     {
                 for (Database* db : dbs) db->CloseHandles();
                 dbs.clear();
 }
-#line 365 "./src/objects/database.lzz"
+#line 374 "./src/objects/database.lzz"
 std::set <Database*, Database::CompareDatabase> Database::dbs;
-#line 366 "./src/objects/database.lzz"
+#line 375 "./src/objects/database.lzz"
 v8::Persistent <v8::Function> Database::SqliteError;
-#line 367 "./src/objects/database.lzz"
+#line 376 "./src/objects/database.lzz"
 int const Database::MAX_BUFFER_SIZE;
-#line 368 "./src/objects/database.lzz"
+#line 377 "./src/objects/database.lzz"
 int const Database::MAX_STRING_SIZE;
 #line 6 "./src/objects/statement.lzz"
 v8::MaybeLocal <v8::Object> Statement::New (v8::Isolate * isolate, v8::Local <v8::Object> database, v8::Local <v8::String> source)

--- a/src/better_sqlite3.hpp
+++ b/src/better_sqlite3.hpp
@@ -305,47 +305,47 @@ private:
   static void JS_aggregate (v8::FunctionCallbackInfo <v8 :: Value> const & info);
 #line 307 "./src/objects/database.lzz"
   static void JS_loadExtension (v8::FunctionCallbackInfo <v8 :: Value> const & info);
-#line 321 "./src/objects/database.lzz"
+#line 330 "./src/objects/database.lzz"
   static void JS_close (v8::FunctionCallbackInfo <v8 :: Value> const & info);
-#line 332 "./src/objects/database.lzz"
+#line 341 "./src/objects/database.lzz"
   static void JS_defaultSafeIntegers (v8::FunctionCallbackInfo <v8 :: Value> const & info);
-#line 339 "./src/objects/database.lzz"
-  static void JS_open (v8::Local <v8 :: String> _, v8::PropertyCallbackInfo <v8 :: Value> const & info);
-#line 343 "./src/objects/database.lzz"
-  static void JS_inTransaction (v8::Local <v8 :: String> _, v8::PropertyCallbackInfo <v8 :: Value> const & info);
 #line 348 "./src/objects/database.lzz"
+  static void JS_open (v8::Local <v8 :: String> _, v8::PropertyCallbackInfo <v8 :: Value> const & info);
+#line 352 "./src/objects/database.lzz"
+  static void JS_inTransaction (v8::Local <v8 :: String> _, v8::PropertyCallbackInfo <v8 :: Value> const & info);
+#line 357 "./src/objects/database.lzz"
   void CloseHandles ();
-#line 360 "./src/objects/database.lzz"
+#line 369 "./src/objects/database.lzz"
   static void AtExit (void * _);
-#line 365 "./src/objects/database.lzz"
-  static std::set <Database*, Database::CompareDatabase> dbs;
-#line 366 "./src/objects/database.lzz"
-  static v8::Persistent <v8::Function> SqliteError;
-#line 367 "./src/objects/database.lzz"
-  static int const MAX_BUFFER_SIZE = node::Buffer::kMaxLength > INT_MAX ? INT_MAX : static_cast<int>(node::Buffer::kMaxLength);
-#line 368 "./src/objects/database.lzz"
-  static int const MAX_STRING_SIZE = v8::String::kMaxLength > INT_MAX ? INT_MAX : static_cast<int>(v8::String::kMaxLength);
-#line 370 "./src/objects/database.lzz"
-  sqlite3 * const db_handle;
-#line 371 "./src/objects/database.lzz"
-  bool open;
-#line 372 "./src/objects/database.lzz"
-  bool busy;
-#line 373 "./src/objects/database.lzz"
-  bool pragma_mode;
 #line 374 "./src/objects/database.lzz"
-  bool safe_ints;
+  static std::set <Database*, Database::CompareDatabase> dbs;
 #line 375 "./src/objects/database.lzz"
-  bool was_js_error;
+  static v8::Persistent <v8::Function> SqliteError;
 #line 376 "./src/objects/database.lzz"
-  bool const has_logger;
+  static int const MAX_BUFFER_SIZE = node::Buffer::kMaxLength > INT_MAX ? INT_MAX : static_cast<int>(node::Buffer::kMaxLength);
 #line 377 "./src/objects/database.lzz"
-  unsigned short int iterators;
-#line 378 "./src/objects/database.lzz"
-  CopyablePersistent <v8::Value> const logger;
+  static int const MAX_STRING_SIZE = v8::String::kMaxLength > INT_MAX ? INT_MAX : static_cast<int>(v8::String::kMaxLength);
 #line 379 "./src/objects/database.lzz"
-  std::set <Statement*, Database::CompareStatement> stmts;
+  sqlite3 * const db_handle;
 #line 380 "./src/objects/database.lzz"
+  bool open;
+#line 381 "./src/objects/database.lzz"
+  bool busy;
+#line 382 "./src/objects/database.lzz"
+  bool pragma_mode;
+#line 383 "./src/objects/database.lzz"
+  bool safe_ints;
+#line 384 "./src/objects/database.lzz"
+  bool was_js_error;
+#line 385 "./src/objects/database.lzz"
+  bool const has_logger;
+#line 386 "./src/objects/database.lzz"
+  unsigned short int iterators;
+#line 387 "./src/objects/database.lzz"
+  CopyablePersistent <v8::Value> const logger;
+#line 388 "./src/objects/database.lzz"
+  std::set <Statement*, Database::CompareStatement> stmts;
+#line 389 "./src/objects/database.lzz"
   std::set <Backup*, Database::CompareBackup> backups;
 };
 #line 1 "./src/objects/statement.lzz"

--- a/src/objects/database.lzz
+++ b/src/objects/database.lzz
@@ -312,7 +312,16 @@ private:
 		REQUIRE_DATABASE_NO_ITERATORS(db);
 		v8::String::Utf8Value filename(EXTRACT_STRING(OnlyIsolate, filenameString));
 		char* error;
-		int status = sqlite3_load_extension(db->db_handle, *filename, NULL, &error);
+		int status;
+		// Allow optional second argument which specifies the 'entry point'.
+		// see: https://www.sqlite.org/c3ref/load_extension.html
+		if (info.Length() > 1) {
+			REQUIRE_ARGUMENT_STRING(second, v8::Local<v8::String> entryPointString);
+			v8::String::Utf8Value entry_point(EXTRACT_STRING(OnlyIsolate, entryPointString));
+			status = sqlite3_load_extension(db->db_handle, *filename, *entry_point, &error);
+		} else {
+			status = sqlite3_load_extension(db->db_handle, *filename, NULL, &error);
+		}
 		if (status == SQLITE_OK) info.GetReturnValue().Set(info.This());
 		else ThrowSqliteError(error, status);
 		sqlite3_free(error);

--- a/test/34.database.load-extension.js
+++ b/test/34.database.load-extension.js
@@ -4,17 +4,20 @@ const path = require('path');
 const Database = require('../.');
 
 describe('Database#loadExtension()', function () {
-	let filepath;
+	const extensions = ['test_extension', 'test_extension_custom_entry_point'];
+	let filepath = {};
 	before(function () {
-		const releaseFilepath = path.join(__dirname, '..', 'build', 'Release', 'test_extension.node');
-		const debugFilepath = path.join(__dirname, '..', 'build', 'Debug', 'test_extension.node');
-		try {
-			fs.accessSync(releaseFilepath);
-			filepath = releaseFilepath;
-		} catch (_) {
-			fs.accessSync(debugFilepath);
-			filepath = debugFilepath;
-		}
+		extensions.forEach(function(extensionName){
+			const releaseFilepath = path.join(__dirname, '..', 'build', 'Release', extensionName + '.node');
+			const debugFilepath = path.join(__dirname, '..', 'build', 'Debug', extensionName + '.node');
+			try {
+				fs.accessSync(releaseFilepath);
+				filepath[extensionName] = releaseFilepath;
+			} catch (_) {
+				fs.accessSync(debugFilepath);
+				filepath[extensionName] = debugFilepath;
+			}
+		});
 	});
 	beforeEach(function () {
 		this.db = new Database(util.next());
@@ -28,21 +31,21 @@ describe('Database#loadExtension()', function () {
 		expect(() => this.db.loadExtension(undefined)).to.throw(TypeError);
 		expect(() => this.db.loadExtension(null)).to.throw(TypeError);
 		expect(() => this.db.loadExtension(123)).to.throw(TypeError);
-		expect(() => this.db.loadExtension(new String(filepath))).to.throw(TypeError);
-		expect(() => this.db.loadExtension([filepath])).to.throw(TypeError);
+		expect(() => this.db.loadExtension(new String(filepath.test_extension))).to.throw(TypeError);
+		expect(() => this.db.loadExtension([filepath.test_extension])).to.throw(TypeError);
 	});
 	it('should throw an exception if the database is busy', function () {
 		let invoked = false;
 		for (const value of this.db.prepare('select 555').pluck().iterate()) {
 			expect(value).to.equal(555);
-			expect(() => this.db.loadExtension(filepath)).to.throw(TypeError);
+			expect(() => this.db.loadExtension(filepath.test_extension)).to.throw(TypeError);
 			invoked = true;
 		}
 		expect(invoked).to.be.true;
 	});
 	it('should throw an exception if the extension is not found', function () {
 		try {
-			this.db.loadExtension(filepath + 'x');
+			this.db.loadExtension(filepath.test_extension + 'x');
 		} catch (err) {
 			expect(err).to.be.an.instanceof(Database.SqliteError);
 			expect(err.message).to.be.a('string');
@@ -54,22 +57,45 @@ describe('Database#loadExtension()', function () {
 		throw new Error('This code should not have been reached');
 	});
 	it('should register the specified extension', function () {
-		expect(this.db.loadExtension(filepath)).to.equal(this.db);
+		expect(this.db.loadExtension(filepath.test_extension)).to.equal(this.db);
 		expect(this.db.prepare('SELECT testExtensionFunction(NULL, 123, 99, 2)').pluck().get()).to.equal(4);
 		expect(this.db.prepare('SELECT testExtensionFunction(NULL, 2)').pluck().get()).to.equal(2);
 	});
-	it('should not allow registering extensions with SQL', function () {
-		expect(() => this.db.prepare('SELECT load_extension(?)').get(filepath)).to.throw(Database.SqliteError);
-		expect(this.db.loadExtension(filepath)).to.equal(this.db);
-		expect(() => this.db.prepare('SELECT load_extension(?)').get(filepath)).to.throw(Database.SqliteError);
-		this.db.close();
-		this.db = new Database(util.next());
+	it('should register the specified extension when specifying the standard entry_point', function () {
+		expect(this.db.loadExtension(filepath.test_extension, 'sqlite3_extension_init')).to.equal(this.db);
+		expect(this.db.prepare('SELECT testExtensionFunction(NULL, 123, 99, 2)').pluck().get()).to.equal(4);
+		expect(this.db.prepare('SELECT testExtensionFunction(NULL, 2)').pluck().get()).to.equal(2);
+	});
+	it('should throw an exception if the entry_point is not found', function () {
 		try {
-			this.db.loadExtension(filepath + 'x');
+			this.db.loadExtension(filepath.test_extension, 'invalid_entry_point');
 		} catch (err) {
-			expect(() => this.db.prepare('SELECT load_extension(?)').get(filepath)).to.throw(Database.SqliteError);
+			expect(err).to.be.an.instanceof(Database.SqliteError);
+			expect(err.message).to.be.a('string');
+			expect(err.message.length).to.be.above(0);
+			expect(err.message).to.not.equal('not an error');
+			expect(err.code).to.equal('SQLITE_ERROR');
 			return;
 		}
 		throw new Error('This code should not have been reached');
+	});
+	it('should not allow registering extensions with SQL', function () {
+		expect(() => this.db.prepare('SELECT load_extension(?)').get(filepath.test_extension)).to.throw(Database.SqliteError);
+		expect(this.db.loadExtension(filepath.test_extension)).to.equal(this.db);
+		expect(() => this.db.prepare('SELECT load_extension(?)').get(filepath.test_extension)).to.throw(Database.SqliteError);
+		this.db.close();
+		this.db = new Database(util.next());
+		try {
+			this.db.loadExtension(filepath.test_extension + 'x');
+		} catch (err) {
+			expect(() => this.db.prepare('SELECT load_extension(?)').get(filepath.test_extension)).to.throw(Database.SqliteError);
+			return;
+		}
+		throw new Error('This code should not have been reached');
+	});
+	it('should register the specified extension when specifying a non-standard entry_point', function () {
+		expect(this.db.loadExtension(filepath.test_extension_custom_entry_point, 'custom_extension_init')).to.equal(this.db);
+		expect(this.db.prepare('SELECT testExtensionFunction(NULL, 123, 99, 2)').pluck().get()).to.equal(4);
+		expect(this.db.prepare('SELECT testExtensionFunction(NULL, 2)').pluck().get()).to.equal(2);
 	});
 });


### PR DESCRIPTION
Heya,

This PR adds an optional second argument to `loadExtension()` which allows users to explicitly specify the extension entry point.
`.loadExtension(path)` -> `.loadExtension(path, [entry_point])`

The motivation for this work is outlined in: https://github.com/JoshuaWise/better-sqlite3/issues/363

This is my first and only work in `c++` but I think it cleaned up ok?
Let me know if there are any n00b issues I'm missing 🤣

~~I've not included the compiled assets from `npm run rebuild-debug` because that just seemed wrong.~~
~~I tried running `npm run rebuild-release` but I don't seem to have permission to do something there.~~
~~Anyhoo, maybe it's best you check it over before releasing anyway.~~

[edit] Added compiled assets from `npm run rebuild-release` in a second commit, let me know if I should squash those two together?

Cheers 🙇 

closes https://github.com/JoshuaWise/better-sqlite3/issues/363