### PR TITLE
support all SQLite journal modes

### DIFF
--- a/test/12.database.pragma.js
+++ b/test/12.database.pragma.js
@@ -49,6 +49,21 @@ describe('Database#pragma()', function () {
 		this.db.pragma('journal_mode = wal');
 		expect(this.db.pragma('journal_mode', { simple: true })).to.equal('wal');
 	});
+	// https://www.sqlite.org/pragma.html#pragma_journal_mode
+	it('should support all journal modes', function () {
+		this.db.pragma('journal_mode = delete');
+		expect(this.db.pragma('journal_mode', { simple: true })).to.equal('delete');
+		this.db.pragma('journal_mode = truncate');
+		expect(this.db.pragma('journal_mode', { simple: true })).to.equal('truncate');
+		this.db.pragma('journal_mode = persist');
+		expect(this.db.pragma('journal_mode', { simple: true })).to.equal('persist');
+		this.db.pragma('journal_mode = memory');
+		expect(this.db.pragma('journal_mode', { simple: true })).to.equal('memory');
+		this.db.pragma('journal_mode = wal');
+		expect(this.db.pragma('journal_mode', { simple: true })).to.equal('wal');
+		this.db.pragma('journal_mode = off');
+		expect(this.db.pragma('journal_mode', { simple: true })).to.equal('off');
+	});
 	it('should respect readonly connections', function () {
 		this.db.close();
 		this.db = new Database(util.current(), { readonly: true, fileMustExist: true });


### PR DESCRIPTION
Heya,

I'm using `PRAGMA journal_mode=OFF` in some of my projects and I've noticed that the journal file is still being created 🤷 
Attached to this PR is a failing test case which shows all other modes are supported but not `OFF` for some reason...

<img width="537" alt="Screenshot 2020-04-24 at 14 30 23" src="https://user-images.githubusercontent.com/738069/80213270-36457180-8639-11ea-8bbf-0d3ea6372337.png">

It took me a while to figure out what was going on because the database appears to accept the PRAGMA but when I check, it hasn't 😕 

@JoshuaWise do you have any ideas which part of the code might be preventing this journal mode from working?