### PR TITLE
Upgrade to SQLite 3.32.0

### DIFF
--- a/deps/download.sh
+++ b/deps/download.sh
@@ -18,7 +18,7 @@
 # 3. node-gyp links the two resulting binaries to generate better_sqlite3.node.
 # ===
 
-VERSION="3310100"
+VERSION="3320000"
 YEAR="2020"
 
 DEFINES="


### PR DESCRIPTION
This PR upgrades SQlite to 3.32.0.

Changelog and new features:
https://sqlite.org/releaselog/3_32_0.html