### PR TITLE
Fix monkey patching bug + memory leak when running in Jest

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -13,5 +13,8 @@ exports.wrap = (Class, methodName, wrapper) => {
 	if (typeof originalMethod !== 'function') {
 		throw new TypeError(`Missing method ${methodName}`);
 	}
-	Class.prototype[methodName] = wrapper(originalMethod);
+	if (!originalMethod.alreadyWrapped) {
+		Class.prototype[methodName] = wrapper(originalMethod);
+		Class.prototype[methodName].alreadyWrapped = true;
+	}
 };


### PR DESCRIPTION
Fixes #414 

When running https://github.com/pelotom/better-sqlite3-jest-bug against this patch, we can see that the error is gone and memory stays constant:

![image](https://user-images.githubusercontent.com/128019/84855550-3484a280-b019-11ea-844b-97fd10e14bc2.png)
