### PR TITLE
Adopt C++14

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -9,9 +9,9 @@
       'target_name': 'better_sqlite3',
       'dependencies': ['deps/sqlite3.gyp:sqlite3'],
       'sources': ['src/better_sqlite3.cpp'],
-      'cflags': ['-std=c++11'],
+      'cflags': ['-std=c++14'],
       'xcode_settings': {
-        'OTHER_CPLUSPLUSFLAGS': ['-std=c++11', '-stdlib=libc++'],
+        'OTHER_CPLUSPLUSFLAGS': ['-std=c++14', '-stdlib=libc++'],
       },
     },
     {


### PR DESCRIPTION
V8 has required C++14 since ~2017. It appears that changes in recent V8 versions (8.6+) have brought C++14 features into the parts of V8 that `better-sqlite3` builds against, causing native module compilation to fail. (I observed this when updating from Electron 10, which uses V8 8.5, to Electron 11, which uses V8 8.7.) Updating to the C++14 standard resolves this issue and gets `better-sqlite3` building again.

Resolves #494.