### PR TITLE
Fix multi-wrap issue of class methods if library is imported multiple times

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -37,7 +37,7 @@ function Database(filenameGiven, options) {
 // Persist list of already wrapped methods
 CPPDatabase.prototype.wrappedMethods = function() {
 	if(!CPPDatabase.prototype.hasOwnProperty('wrappedMethodsSet')) {
-		CPPDatabase.prototype.wrappedMethodsSet = new Set();
+		CPPDatabase.prototype.wrappedMethodsSet = new WeakSet();
 	}
 	return CPPDatabase.prototype.wrappedMethodsSet;
 }

--- a/lib/database.js
+++ b/lib/database.js
@@ -34,6 +34,14 @@ function Database(filenameGiven, options) {
 	return new CPPDatabase(filename, filenameGiven, anonymous, readonly, fileMustExist, timeout, verbose || null);
 }
 
+// Persist list of already wrapped methods
+CPPDatabase.prototype.wrappedMethods = function() {
+	if(!CPPDatabase.prototype.hasOwnProperty('wrappedMethodsSet')) {
+		CPPDatabase.prototype.wrappedMethodsSet = new Set();
+	}
+	return CPPDatabase.prototype.wrappedMethodsSet;
+}
+
 setErrorConstructor(require('./sqlite-error'));
 util.wrap(CPPDatabase, 'pragma', require('./pragma'));
 util.wrap(CPPDatabase, 'function', require('./function'));

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,5 +1,4 @@
 'use strict';
-const wrappedMethods = new WeakSet();
 
 exports.getBooleanOption = (options, key) => {
 	let value = false;
@@ -14,9 +13,11 @@ exports.wrap = (Class, methodName, wrapper) => {
 	if (typeof originalMethod !== 'function') {
 		throw new TypeError(`Missing method ${methodName}`);
 	}
-	if (!wrappedMethods.has(originalMethod)) {
+
+	// Check if this method was previously wrapped for this class
+	if (!Class.prototype.wrappedMethods().has(originalMethod)) {
 		const wrapped = wrapper(originalMethod);
-		wrappedMethods.add(wrapped);
+		Class.prototype.wrappedMethods().add(wrapped);
 		Class.prototype[methodName] = wrapped;
 	}
 };


### PR DESCRIPTION
Hi @JoshuaWise,

thank you very much for bringing better-sqlite3 to life! :)

While integrating the library into our software, we noticed that for our jest testing suites all but the first suite failed to run (using `--runInBand`). Taking a closer look, it seems that for each test suite, the library is imported again into the same environment causing the issue we observed. 
The resulting error looks something like this:

```
TypeError: Expected first argument to be a string
at Database.pragma (node_modules/better-sqlite3/lib/pragma.js:7:41)
at Database.pragma (node_modules/better-sqlite3/lib/pragma.js:12:17)
```

A non-string is passed to the pragma function in `lib/pragma.js` - actually this is line 12 calling the function itself with boolean `true`. The behavior we see here is (kind of) correct - but caused by wrapping the pragma function from the C++ code twice.
The wrap function in `lib/utils.js` seems to be the issue here - it is run every time, but does not sufficiently check if the function it is wrapping got wrapped previously for our use case (although we initially thought that line 17 would suffice).

To fix this behavior, we suggest to store the set of wrapped methods within the CPPDatabase class itself as a property. This will ensure that the set will exist as long as the wrapped methods of the class do and that the list is always consistent. For our precise use case, the fix proposed in this PR completely resolves the issue.

Would it be possible to include this fix in the upstream branch? Thank you very much! :+1:
