### PR TITLE
[Electron] Add support for 12.x, drop 9.x (EOL)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ before_script:
 before_deploy:
 - npm run build-release
 - $(npm bin)/prebuild -r node -t 10.20.0 -t 12.0.0 -t 14.0.0 --include-regex 'better_sqlite3.node$'
-- $(npm bin)/prebuild -r electron -t 9.0.0 -t 10.0.0 -t 11.0.0 --include-regex 'better_sqlite3.node$'
+- $(npm bin)/prebuild -r electron -t 10.0.0 -t 11.0.0 -t 12.0.0 --include-regex 'better_sqlite3.node$'
 deploy:
   provider: releases
   api_key:


### PR DESCRIPTION
Based on the following release announcement
https://www.electronjs.org/releases/stable#12.0.0
https://www.electronjs.org/releases/stable#end-of-support-for-9xy