### PR TITLE
Fixes GLIBC 2.29 issues, electron issues, and more

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
   publish:
     if: ${{ github.event_name == 'release' }}
     name: Publishing to NPM
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs: test
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-18.04
           - macos-latest
           - windows-latest
         node:
@@ -54,7 +54,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-18.04
           - macos-latest
           - windows-latest
     name: Prebuild on ${{ matrix.os }}


### PR DESCRIPTION
This fixes the following issues:
- Broken prebuild linux packages for anything < Ubuntu 20.04, Debian 11, and more
- Running Electron apps on any OS < Ubuntu 20.04, and Debian 11
- Unable to install better-sqlite3 on those OSs

## Compatibility
This causes _no_ compatibility issues with later versions of GLIBC, so all new OSes work just fine. I have confirmed this on Ubuntu 20.04 using a package built on 18.04. It should be a set and forget fix.

This took some real sleuthing to figure out for my app. Hope this helps others!

## Workaround until merge
Workaround until this is merged: Downgrade to `7.1.2`, as this was built on 18.04 before Github changed `ubuntu-latest` build images to 20.04 instead of 18.04

Fix #586
Fix #403 