### PR TITLE
Fix inserting empty BLOBs instead of NULL, fixes #651

### DIFF
--- a/src/util/data.lzz
+++ b/src/util/data.lzz
@@ -21,7 +21,7 @@
 	} else if (node::Buffer::HasInstance(value)) {                             \
 		return sqlite3_##to##_blob(                                            \
 			__VA_ARGS__,                                                       \
-			(node::Buffer::Length(value) == NULL ? "" : node::Buffer::Data(value)), \
+			(node::Buffer::Length(value) == 0 ? "" : node::Buffer::Data(value)), \
 			node::Buffer::Length(value),                                       \
 			SQLITE_TRANSIENT                                                   \
 		);                                                                     \

--- a/src/util/data.lzz
+++ b/src/util/data.lzz
@@ -21,7 +21,7 @@
 	} else if (node::Buffer::HasInstance(value)) {                             \
 		return sqlite3_##to##_blob(                                            \
 			__VA_ARGS__,                                                       \
-			node::Buffer::Data(value),                                         \
+			(node::Buffer::Length(value) == NULL ? "" : node::Buffer::Data(value)), \
 			node::Buffer::Length(value),                                       \
 			SQLITE_TRANSIENT                                                   \
 		);                                                                     \

--- a/test/20.statement.run.js
+++ b/test/20.statement.run.js
@@ -167,4 +167,8 @@ describe('Statement#run()', function () {
 		}
 		expect(i).to.equal(11);
 	});
+	it('should insert an empty Buffer', function () {
+		this.db.prepare('CREATE TABLE buffers (a BLOB NOT NULL)').run();
+		this.db.prepare('INSERT INTO buffers VALUES (?)').run(Buffer.alloc(0));
+	});
 });

--- a/test/21.statement.get.js
+++ b/test/21.statement.get.js
@@ -107,9 +107,12 @@ describe('Statement#get()', function () {
 		).to.throw(RangeError);
 	});
 	it('should get an empty Buffer', function () {
+		let result = this.db.prepare('SELECT ?').pluck(true).get(Buffer.alloc(0));
+		expect(result).to.deep.equal(Buffer.alloc(0));
+
 		this.db.prepare('CREATE TABLE buffers (a BLOB NOT NULL)').run();
 		this.db.prepare("INSERT INTO buffers VALUES (x'')").run();
-		let result = this.db.prepare('SELECT a FROM buffers').pluck(true).get();
+		result = this.db.prepare('SELECT a FROM buffers').pluck(true).get();
 		expect(result).to.deep.equal(Buffer.alloc(0));
 	});
 });

--- a/test/21.statement.get.js
+++ b/test/21.statement.get.js
@@ -106,4 +106,10 @@ describe('Statement#get()', function () {
 			this.db.prepare(SQL2).get({})
 		).to.throw(RangeError);
 	});
+	it('should get an empty Buffer', function () {
+		this.db.prepare('CREATE TABLE buffers (a BLOB NOT NULL)').run();
+		this.db.prepare("INSERT INTO buffers VALUES (x'')").run();
+		let result = this.db.prepare('SELECT a FROM buffers').pluck(true).get();
+		expect(result).to.deep.equal(Buffer.alloc(0));
+	});
 });


### PR DESCRIPTION
Code and tests are ugli and don't follow your style. But this fixes the "should insert an empty Buffer" test which would otherwise fail with "SqliteError: NOT NULL constraint failed: buffers.a"

This should save you some time, adjust it to your style.

It's a mix of https://github.com/ericsink/SQLitePCL.raw/commit/e324598161b6941e1e79ccfa7088ca281f47294b and https://www.mail-archive.com/sqlite-users@mailinglists.sqlite.org/msg35366.html