### PR TITLE
Encapsulate the internal SQLite

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -13,6 +13,14 @@
       'xcode_settings': {
         'OTHER_CPLUSPLUSFLAGS': ['-std=c++14', '-stdlib=libc++'],
       },
+      'conditions': [
+        ['OS=="linux"', {
+          'ldflags': [
+            '-Wl,-Bsymbolic',
+            '-Wl,--exclude-libs,ALL',
+          ],
+        }],
+      ],
     },
     {
       'target_name': 'test_extension',


### PR DESCRIPTION
Add linker flags to
 - prevent the dynamic linker from using an external SQLite for this
   library (`-Bsymbolic`) and
 - prevent the dynamic linker from using the internal SQLite for other
   libraries (`--exclude-libs ALL`).

This is just a (conflict-free) cherry-pick of a Signal-specific fix in
https://github.com/signalapp/better-sqlite3/pull/3 that seems OK to upstream further.