### PR TITLE
add arm64 prebuilds for alpine

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,3 +82,4 @@ jobs:
       - run: apk add build-base git python3 --update-cache
       - run: npm install --ignore-scripts
       - run: npx --no-install prebuild -r node -t 10.20.0 -t 12.0.0 -t 14.0.0 -t 16.0.0 --include-regex 'better_sqlite3.node$' -u ${{ secrets.GITHUB_TOKEN }}
+      - run: npx --no-install prebuild -r node -t 10.20.0 -t 12.0.0 -t 14.0.0 -t 16.0.0 --include-regex 'better_sqlite3.node$' --arch aarch64 -u ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,4 +82,16 @@ jobs:
       - run: apk add build-base git python3 --update-cache
       - run: npm install --ignore-scripts
       - run: npx --no-install prebuild -r node -t 10.20.0 -t 12.0.0 -t 14.0.0 -t 16.0.0 --include-regex 'better_sqlite3.node$' -u ${{ secrets.GITHUB_TOKEN }}
-      - run: npx --no-install prebuild -r node -t 10.20.0 -t 12.0.0 -t 14.0.0 -t 16.0.0 --include-regex 'better_sqlite3.node$' --arch aarch64 -u ${{ secrets.GITHUB_TOKEN }}
+
+  prebuild-arm64-alpine:
+    name: Prebuild on arm64 alpine
+    runs-on: ubuntu-latest
+    needs: publish
+    steps:
+      - uses: docker/setup-qemu-action@v1
+      - run: |
+          docker run --rm --entrypoint /bin/sh --platform linux/arm64 node:16-alpine -c "apk add build-base git python3 --update-cache && \
+          git clone https://github.com/JoshuaWise/better-sqlite3 && \
+          cd better-sqlite3 && \
+          npm install --ignore-scripts && \
+          npx --no-install prebuild -r node -t 10.20.0 -t 12.0.0 -t 14.0.0 -t 16.0.0 --include-regex 'better_sqlite3.node$' -u ${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Arm64 is getting more and more popular with the oracle servers and raspberry pi's so it would be great to have prebuilds for it.
Could have probably added arm64 support for other builds too but didn't want to start testing if they actually work.