### PR TITLE
Update `prebuild-install` to `v7.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "bindings": "^1.5.0",
-    "prebuild-install": "^6.1.4",
+    "prebuild-install": "^7.0.0",
     "tar": "^6.1.11"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #713, #694.

`electron-builder` uses a dependency named [`app-builder`](https://github.com/develar/app-builder) that uses whatever version of `prebuild-install` used by the project simply as a peer dependency. So this simple update will fix the issues related to installing pre-built binaries for newer versions of Electron (14.x, 15.x, 16.x).

For the moment, users can run `npm install -D prebuild-install@latest` on the root project and fix the issue.