### PR TITLE
Use `github` context properties in `arm64-alpine` prebuild job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,7 @@ jobs:
       - uses: docker/setup-qemu-action@v1
       - run: |
           docker run --rm --entrypoint /bin/sh --platform linux/arm64 node:16-alpine -c "apk add build-base git python3 --update-cache && \
-          git clone https://github.com/JoshuaWise/better-sqlite3 && \
-          cd better-sqlite3 && \
+          git clone ${{ github.event.repository.clone_url }} && \
+          cd ${{ github.event.repository.name }} && \
           npm install --ignore-scripts && \
           npx --no-install prebuild -r node -t 10.20.0 -t 12.0.0 -t 14.0.0 -t 16.0.0 --include-regex 'better_sqlite3.node$' -u ${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Using properties from `github.event.repository` instead of hardcoded repo URLs and names will prevent the job from being broken in the slight chance of this repo being [moved to an organization](https://github.com/JoshuaWise/better-sqlite3/pull/724#issuecomment-974501165) in the future. It's safer even if the redirects are set.