### PR TITLE
Automate the process of updating SQLite version

### DIFF
--- a/.github/workflows/update-sqlite.yml
+++ b/.github/workflows/update-sqlite.yml
@@ -1,0 +1,47 @@
+name: update-sqlite
+
+on:
+  workflow_dispatch:
+    inputs:
+      year:
+        description: 'SQLite release year'
+        required: true
+      version:
+        description: 'SQLite version (encoded)'
+        required: true
+
+jobs:
+  download-and-update:
+    name: Download and update SQLite
+    runs-on: ubuntu-latest
+    env:
+      ENV_YEAR: ${{ github.event.inputs.year }}
+      ENV_VERSION: ${{ github.event.inputs.version }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - name: Create new update branch
+        run: git checkout -b sqlite-update-${{ env.ENV_VERSION }}
+      - name: Update download script
+        run: |
+          sed -Ei "s/YEAR=\"[0-9]+\"/YEAR=\"${{ env.ENV_YEAR }}\"/g" ./deps/download.sh
+          sed -Ei "s/VERSION=\"[0-9]+\"/VERSION=\"${{ env.ENV_VERSION }}\"/g" ./deps/download.sh
+          echo "ENV_TRUE_VERSION=$((10#${ENV_VERSION:0:1})).$((10#${ENV_VERSION:1:2})).$((10#${ENV_VERSION:3:2}))" >> $GITHUB_ENV
+      - name: Downlod, compile and package SQLite
+        run: npm run download
+      - name: Push update branch
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: 'Update SQLite to `${{ env.ENV_TRUE_VERSION }}`'
+          branch: sqlite-update-${{ env.ENV_VERSION }}
+      - name: Create new PR
+        uses: repo-sync/pull-request@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          source_branch: sqlite-update-${{ env.ENV_VERSION }}
+          pr_title: 'Update SQLite to \`${{ env.ENV_TRUE_VERSION }}\`'
+          pr_body: 'This is an automated pull request, updating SQLite version to \`${{ env.ENV_TRUE_VERSION }}\`.'


### PR DESCRIPTION
This PR creates a new workflow dedicated for the process of updating SQLite.
The thought behind this addition is that it seems much easier and cleaner in regards of both safety with binary files and wide testing. Just thought of creating this since the topic of safety was brought up by @JoshuaWise recently in a PR conversation.

The workflow is manually dispatched and presents you with the following prompt which are also the variables needed for the download script.

![image](https://user-images.githubusercontent.com/6711514/149999816-c53317a5-e242-4b64-8d2d-1fc9d4354251.png)

### **Notes:**
🟢 This PR does not break the current manual update flow. In fact as seen in the diff, it's done without changing a single line of code in the download script.
🟢 Instead of directly pushing the changes, this workflow will do the changes on a new branch and an automated pull request will be created from that branch which will then be tested automatically just like any other PR.
🟢 The functionality of this workflow (_with slight changes_) has already been tested at [`better-sqlite3-multiple-ciphers`](https://github.com/m4heshd/better-sqlite3-multiple-ciphers/blob/master/.github/workflows/update-sqlite3mc.yml).

🔴 The automatically created PR will **not** trigger tests/checks at the moment because of a [limitation imposed by GitHub](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#triggering-a-workflow-from-a-workflow) when using `GITHUB_TOKEN`. This can be easily fixed by using a **Personal access token** with `repo` privileges as the secret just in [this step](https://github.com/m4heshd/better-sqlite3/blob/f9eb714399f80d6ec794dfcd637f963bb6737618/.github/workflows/update-sqlite.yml#L44).
If you check [this automated PR](https://github.com/m4heshd/better-sqlite3-multiple-ciphers/pull/8) you can see that it triggered the tests and works as intended by using a PAT instead of `GITHUB_TOKEN`.

Hope this was worth the time and effort. ✌🏼