### PR TITLE
feature: add armv7 prebuilds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,3 +96,17 @@ jobs:
           cd ${{ github.event.repository.name }} && \
           npm install --ignore-scripts && \
           npx --no-install prebuild -r node -t 10.20.0 -t 12.0.0 -t 14.0.0 -t 16.0.0 --include-regex 'better_sqlite3.node$' -u ${{ secrets.GITHUB_TOKEN }}"
+
+  prebuild-armv7-alpine:
+    name: Prebuild on armhf alpine
+    runs-on: ubuntu-latest
+    needs: publish
+    steps:
+      - uses: docker/setup-qemu-action@v1
+      - run: |
+          docker run --rm --entrypoint /bin/sh --platform linux/arm/v7 node:16-alpine -c "apk add build-base git python3 --update-cache && \
+          git clone ${{ github.event.repository.clone_url }} && \
+          cd ${{ github.event.repository.name }} && \
+          npm install --ignore-scripts && \
+          uname -a && \
+          npx --no-install prebuild -r node -t 10.20.0 -t 12.0.0 -t 14.0.0 -t 16.0.0 --include-regex 'better_sqlite3.node$' -u ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use qemu and --platform linux/arm/v7 to cross build
binaries for 32 bit arm v7.

Based on #714, see also #601.

Untested, but [a slimmed down version seems to build ok](https://github.com/tkurki/better-sqlite3/runs/4992427898?check_suite_focus=true#step:3:95).