### PR TITLE
Add Linux prebuilt binaries for `armv7` and `arm64` and other improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,3 +102,21 @@ jobs:
           cd /tmp/project && \
           npm install --ignore-scripts && \
           npx --no-install prebuild -r node -t 10.20.0 -t 12.0.0 -t 14.0.0 -t 16.0.0 --include-regex 'better_sqlite3.node$' -u ${{ secrets.GITHUB_TOKEN }}"
+
+  prebuild-linux-arm:
+    strategy:
+      matrix:
+        arch:
+          - arm/v7
+          - arm64
+    name: Prebuild on Linux (${{ matrix.arch }})
+    runs-on: ubuntu-latest
+    needs: publish
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/setup-qemu-action@v1
+      - run: |
+          docker run --rm -v $(pwd):/tmp/project --entrypoint /bin/sh --platform linux/${{ matrix.arch }} node:16 -c "\
+          cd /tmp/project && \
+          npm install --ignore-scripts && \
+          npx --no-install prebuild -r node -t 10.20.0 -t 12.0.0 -t 14.0.0 -t 16.0.0 --include-regex 'better_sqlite3.node$' -u ${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,15 +84,21 @@ jobs:
       - run: npm install --ignore-scripts
       - run: npx --no-install prebuild -r node -t 10.20.0 -t 12.0.0 -t 14.0.0 -t 16.0.0 --include-regex 'better_sqlite3.node$' -u ${{ secrets.GITHUB_TOKEN }}
 
-  prebuild-arm64-alpine:
-    name: Prebuild on arm64 alpine
+  prebuild-alpine-arm:
+    strategy:
+      matrix:
+        arch:
+          - arm/v7
+          - arm64
+    name: Prebuild on alpine (${{ matrix.arch }})
     runs-on: ubuntu-latest
     needs: publish
     steps:
+      - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1
       - run: |
-          docker run --rm --entrypoint /bin/sh --platform linux/arm64 node:16-alpine -c "apk add build-base git python3 --update-cache && \
-          git clone ${{ github.event.repository.clone_url }} && \
-          cd ${{ github.event.repository.name }} && \
+          docker run --rm -v $(pwd):/tmp/project --entrypoint /bin/sh --platform linux/${{ matrix.arch }} node:16-alpine -c "\
+          apk add build-base git python3 --update-cache && \
+          cd /tmp/project && \
           npm install --ignore-scripts && \
           npx --no-install prebuild -r node -t 10.20.0 -t 12.0.0 -t 14.0.0 -t 16.0.0 --include-regex 'better_sqlite3.node$' -u ${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This PR adds multiple new features and improvements.

- Added `armv7` prebuilt binaries for Alpine
- Added both `armv7` and `arm64` prebuilt binaries for Linux (very useful for Raspbian users)
- All the jobs that runs on Qemu containers now uses `checkout` action which supports correct trigger `ref`
- Added `publish` job completion requirement to all jobs

As always, all these changes were tested on multiple releases, for weeks at [`better-sqlite3-multiple-ciphers`](https://github.com/m4heshd/better-sqlite3-multiple-ciphers/blob/master/.github/workflows/prebuild.yml).